### PR TITLE
Added mac-specific ignore for .DS_Store.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ export_presets.cfg
 .mono/
 data_*/
 mono_crash.*.json
+#Mac-specific ignore:
+.DS_Store


### PR DESCRIPTION
This file is created automatically on macOS systems, so it should be ignored.